### PR TITLE
Added gcc11: Fix math method duplication for clib4 patch

### DIFF
--- a/gcc/11/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
+++ b/gcc/11/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
@@ -1,4 +1,4 @@
-From a065f15c8bb17b6717633ef513e4c2f12f152499 Mon Sep 17 00:00:00 2001
+From 16ffc85499dff829d9ad8a19c510e082dd566c7e Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Feb 2015 20:25:55 +0100
 Subject: [PATCH 01/39] Changes for AmigaOS version of gcc.

--- a/gcc/11/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
+++ b/gcc/11/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
@@ -1,4 +1,4 @@
-From 5901f8aec0e2f6a0f826903cd483cc1b10f63aeb Mon Sep 17 00:00:00 2001
+From 4fb7ff35461f1e07e525b3116f5b52d48782b916 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 14 Nov 2014 20:03:56 +0100
 Subject: [PATCH 02/39] Added new function attribute "lineartags" and pragma

--- a/gcc/11/patches/0003-Disable-.machine-directive-generation.patch
+++ b/gcc/11/patches/0003-Disable-.machine-directive-generation.patch
@@ -1,4 +1,4 @@
-From 07718db105d776cff50b4cd8102132c88ea7c002 Mon Sep 17 00:00:00 2001
+From 6d171c23f179dc2cc4c4b453307cf1e68fdf9e3f Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 9 Jul 2015 06:54:37 +0200
 Subject: [PATCH 03/39] Disable .machine directive generation.

--- a/gcc/11/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
+++ b/gcc/11/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
@@ -1,4 +1,4 @@
-From f7398a949dd5201e983c7d8188d497e548112123 Mon Sep 17 00:00:00 2001
+From 930c3722e664a4f99c735fd6c42017099ca334f6 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 20:56:33 +0100
 Subject: [PATCH 04/39] The default link mode is static for AmigaOS.

--- a/gcc/11/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
+++ b/gcc/11/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
@@ -1,4 +1,4 @@
-From e6ec2d752903863da6dcf190e18c73e346b6b253 Mon Sep 17 00:00:00 2001
+From 5b939e6c73f728ef49172eaa0a4245146d311e46 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 21:39:42 +0100
 Subject: [PATCH 05/39] Disable the usage of /dev/urandom when compiling for

--- a/gcc/11/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
+++ b/gcc/11/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
@@ -1,4 +1,4 @@
-From a01c2a5ac436a00b931a0146cf802f69127c2884 Mon Sep 17 00:00:00 2001
+From d318e946386324491d70b5f0e237532aac758f69 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 5 Dec 2015 13:17:26 +0100
 Subject: [PATCH 06/39] Expand arg zero on AmigaOS using the PROGDIR: assign.

--- a/gcc/11/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
+++ b/gcc/11/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
@@ -1,4 +1,4 @@
-From 6c249f64bd2d0ebf30f51531484ea1742962ee12 Mon Sep 17 00:00:00 2001
+From 2a4c4f2986c93a198947a2c6d7ca9c2395e9f17a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 21 Jan 2016 20:46:59 +0100
 Subject: [PATCH 07/39] Some AmigaOS 4.x compability changes for posix thread

--- a/gcc/11/patches/0008-Added-libstc-support-for-AmigaOS.patch
+++ b/gcc/11/patches/0008-Added-libstc-support-for-AmigaOS.patch
@@ -1,4 +1,4 @@
-From b5b5a3209f4fc3c59198b392b728576612a85f78 Mon Sep 17 00:00:00 2001
+From 85e2c5205402bfcae2a29cfd1a8b6e5471e83cef Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 22 Jan 2016 20:04:50 +0100
 Subject: [PATCH 08/39] Added libstc++ support for AmigaOS.

--- a/gcc/11/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
+++ b/gcc/11/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
@@ -1,4 +1,4 @@
-From c9fb3357d886c3e9561e008b9087c9b75caef37d Mon Sep 17 00:00:00 2001
+From 600b1aced1741bfb5b1b570f2c58a91d893954dd Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 3 Mar 2017 08:52:48 +0100
 Subject: [PATCH 09/39] Enable libatomic for ppc-amigaos.

--- a/gcc/11/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
+++ b/gcc/11/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
@@ -1,4 +1,4 @@
-From 33102a20e983d901be1859333d922cb32459d2b2 Mon Sep 17 00:00:00 2001
+From ef40625fda0fecd7f3eca32a2ad8e22e133fed57 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 23 May 2018 10:54:19 +0200
 Subject: [PATCH 10/39] Implement libat_lock_n() and libat_unlock_n().

--- a/gcc/11/patches/0011-Pretend-C99-compatibility.patch
+++ b/gcc/11/patches/0011-Pretend-C99-compatibility.patch
@@ -1,4 +1,4 @@
-From 60505eb8b49c04957f3e1122484b5e2297f19c8e Mon Sep 17 00:00:00 2001
+From ba202cb15c9d2319d1c730de30b6397ae8f09cf8 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 4 Mar 2017 07:39:21 +0100
 Subject: [PATCH 11/39] Pretend C99 compatibility.

--- a/gcc/11/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
+++ b/gcc/11/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
@@ -1,4 +1,4 @@
-From 75d527aeab41195aa6161eb90ab1c75fb39692ac Mon Sep 17 00:00:00 2001
+From 71a5a44771063d4bd61b4e5f70c5f230c09d2600 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 3 Apr 2018 19:52:01 +0200
 Subject: [PATCH 12/39] Add amigaos-stdint.h for libatomic.

--- a/gcc/11/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
+++ b/gcc/11/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
@@ -1,4 +1,4 @@
-From f5d04240570843fd4419cd0d9ce6f9aa50609145 Mon Sep 17 00:00:00 2001
+From d20fdad6e575d1b6d12edee6d079b8b593529a64 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 22:48:33 +0200
 Subject: [PATCH 13/39] Rerun make maint-deps in libiberty.

--- a/gcc/11/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
+++ b/gcc/11/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
@@ -1,4 +1,4 @@
-From 6a98220e936165ce6238e071fcfda1277ef80392 Mon Sep 17 00:00:00 2001
+From d6ed9c3b9803f8af07bedaaff8a88ca55295bb71 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 23:50:48 +0200
 Subject: [PATCH 14/39] Add custom implementation of various env-related

--- a/gcc/11/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
+++ b/gcc/11/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
@@ -1,4 +1,4 @@
-From 8982a14a86f101333989f8b8959d031209e2401a Mon Sep 17 00:00:00 2001
+From c9f4eeb33c8915dba282932962afad236b0cb23d Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 5 Apr 2018 19:56:45 +0200
 Subject: [PATCH 15/39] Define va_startlinear and va_getlinearva.

--- a/gcc/11/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
+++ b/gcc/11/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
@@ -1,4 +1,4 @@
-From a5b8eb192677e48f84822bc15c20ba8975b5fad5 Mon Sep 17 00:00:00 2001
+From ec8376a9a59f92083cf06527dd04d2e54236cb9f Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Apr 2018 22:02:09 +0200
 Subject: [PATCH 16/39] Fix r2 restoring in the epilog of baserel-restoring

--- a/gcc/11/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
+++ b/gcc/11/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
@@ -1,4 +1,4 @@
-From dd595e5c58180a1ad9e8572bf17dd5cfbfabf789 Mon Sep 17 00:00:00 2001
+From 775575fc02a1e3d0ae7cadb3bad38c6ed70b640a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 19 Apr 2018 21:00:30 +0200
 Subject: [PATCH 17/39] Avoid section anchors in the baserel mode.

--- a/gcc/11/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
+++ b/gcc/11/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
@@ -1,4 +1,4 @@
-From c64cc31006520260c4a23cc23799442e28402415 Mon Sep 17 00:00:00 2001
+From e19d549903b2ece4d57dfa6e717708480d2e0fd1 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 20 Apr 2018 20:04:30 +0200
 Subject: [PATCH 18/39] Respect -nostdinc also for SDK includes.

--- a/gcc/11/patches/0019-Add-_Static_warning.patch
+++ b/gcc/11/patches/0019-Add-_Static_warning.patch
@@ -1,4 +1,4 @@
-From 7e5ea9debe2babeb92ebd4e6d081599ea8441004 Mon Sep 17 00:00:00 2001
+From 2437d070b7d02cbb35dc391186cc2950ad4cb312 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 24 Apr 2018 22:46:21 +0200
 Subject: [PATCH 19/39] Add _Static_warning().

--- a/gcc/11/patches/0020-Rename-lineartags-to-checktags.patch
+++ b/gcc/11/patches/0020-Rename-lineartags-to-checktags.patch
@@ -1,4 +1,4 @@
-From c0a70959ea598b7004bb62e22b42443e090788b4 Mon Sep 17 00:00:00 2001
+From 04d74adf05bf2eebd73697eb776154f07b872f9b Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 27 Apr 2018 22:48:18 +0200
 Subject: [PATCH 20/39] Rename lineartags to checktags.

--- a/gcc/11/patches/0021-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
+++ b/gcc/11/patches/0021-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
@@ -1,4 +1,4 @@
-From 4257f6d9961b0a9e583bf71f8cabcceb92ca44d3 Mon Sep 17 00:00:00 2001
+From 745b37672ee183b1b700de161614fea068a67793 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 28 Apr 2018 08:09:58 +0200
 Subject: [PATCH 21/39] Fix order of AmigaOS PPC sections in the documentation.

--- a/gcc/11/patches/0022-Provide-a-documentation-for-checktags-and-tagtype-at.patch
+++ b/gcc/11/patches/0022-Provide-a-documentation-for-checktags-and-tagtype-at.patch
@@ -1,4 +1,4 @@
-From 4cb533514851a1840dea1ce9d8e20884b45f53e1 Mon Sep 17 00:00:00 2001
+From 5fe229f0b46d1b6598c7d47931ede22a9db5963c Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sun, 29 Apr 2018 00:08:22 +0200
 Subject: [PATCH 22/39] Provide a documentation for checktags and tagtype

--- a/gcc/11/patches/0023-Adapt-libssp-for-AmigaOS.patch
+++ b/gcc/11/patches/0023-Adapt-libssp-for-AmigaOS.patch
@@ -1,4 +1,4 @@
-From ab20508a3cdea818bb37195cea6d2e960b32e8d7 Mon Sep 17 00:00:00 2001
+From 890782e69ce0d00351ae430758285f4a4ae5a7bd Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 22 May 2018 23:14:01 +0200
 Subject: [PATCH 23/39] Adapt libssp for AmigaOS.

--- a/gcc/11/patches/0024-Add-amigaos-thread-model.patch
+++ b/gcc/11/patches/0024-Add-amigaos-thread-model.patch
@@ -1,4 +1,4 @@
-From 1a726f2c22094261ab929462bc51bd250f82e3c4 Mon Sep 17 00:00:00 2001
+From ee37922ebbea60846f39b74f0feb01b8a77e1440 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 4 May 2018 18:22:24 +0200
 Subject: [PATCH 24/39] Add amigaos thread model.

--- a/gcc/11/patches/0025-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
+++ b/gcc/11/patches/0025-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
@@ -1,4 +1,4 @@
-From 32df36c00d3b7244a206c14d8318d67065a75e26 Mon Sep 17 00:00:00 2001
+From 4d4360b5e1de5c450deee821fd8a57c19bb190b6 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 27 Oct 2018 08:06:21 +0200
 Subject: [PATCH 25/39] Add aregparam attribute for functions for the m68k

--- a/gcc/11/patches/0026-gcc10-Don-t-use-poisoned-define.patch
+++ b/gcc/11/patches/0026-gcc10-Don-t-use-poisoned-define.patch
@@ -1,4 +1,4 @@
-From 28c0ba8817d98c02e3eaeb4e1f9f0186ff221efe Mon Sep 17 00:00:00 2001
+From f38396e84296f57034648867fc0226b81ff6c96d Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 17:22:55 +0100
 Subject: [PATCH 26/39] gcc10: Don't use poisoned define.

--- a/gcc/11/patches/0027-gcc10-Remove-unused-variable.patch
+++ b/gcc/11/patches/0027-gcc10-Remove-unused-variable.patch
@@ -1,4 +1,4 @@
-From afab86a678caaa9ac9a9c3c3c20f403d751acebf Mon Sep 17 00:00:00 2001
+From 3bed0ac63b26243fbc788d9a22c52a6bab6d22ed Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 17:25:51 +0100
 Subject: [PATCH 27/39] gcc10: Remove unused variable.

--- a/gcc/11/patches/0028-gcc10-Remove-tagtype-attribute.patch
+++ b/gcc/11/patches/0028-gcc10-Remove-tagtype-attribute.patch
@@ -1,4 +1,4 @@
-From 20b1fd8b7d74b36d7da722bcef98356fea03ec1f Mon Sep 17 00:00:00 2001
+From 9501ebd258e5813e5d0aa892db9af1d7ffc17b63 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 22:05:59 +0100
 Subject: [PATCH 28/39] gcc10: Remove tagtype attribute.

--- a/gcc/11/patches/0029-gcc10-Define-CC1_SPEC.patch
+++ b/gcc/11/patches/0029-gcc10-Define-CC1_SPEC.patch
@@ -1,4 +1,4 @@
-From 266f38251b6aa1c7fd3b8429d2d2b95d0c577f5c Mon Sep 17 00:00:00 2001
+From 1f7888e3cd4128a591182f878362924568b75b22 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 22:07:45 +0100
 Subject: [PATCH 29/39] gcc10: Define CC1_SPEC.

--- a/gcc/11/patches/0030-gcc10-Link-lto-dump-with-athread-native.patch
+++ b/gcc/11/patches/0030-gcc10-Link-lto-dump-with-athread-native.patch
@@ -1,4 +1,4 @@
-From 0fe8d761ed5446ed3c7ca431659958b2498ee613 Mon Sep 17 00:00:00 2001
+From a537af98ec59f4f7ba08136ba587510664d10c59 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 8 Jan 2021 01:02:33 +0100
 Subject: [PATCH 30/39] gcc10: Link lto-dump with -athread=native.

--- a/gcc/11/patches/0031-gcc10-Expose-max_align_t-when-using-clib2.patch
+++ b/gcc/11/patches/0031-gcc10-Expose-max_align_t-when-using-clib2.patch
@@ -1,4 +1,4 @@
-From f55c00ae21292b68738143bbf275ef30e94b7efe Mon Sep 17 00:00:00 2001
+From c9f72b53f5dee33f2478f586a88e5088d922bad5 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 8 Jan 2021 14:03:50 +0100
 Subject: [PATCH 31/39] gcc10: Expose max_align_t when using clib2.

--- a/gcc/11/patches/0032-gcc10-Don-t-define-__STRICT_ANSI__.patch
+++ b/gcc/11/patches/0032-gcc10-Don-t-define-__STRICT_ANSI__.patch
@@ -1,4 +1,4 @@
-From 0c74121b54a3b0c55ede757302dd13f6728d560d Mon Sep 17 00:00:00 2001
+From b1a1fdda89692a5605626bf4414cbcbcfbb28dac Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sun, 7 Feb 2021 19:38:47 +0100
 Subject: [PATCH 32/39] gcc10: Don't define __STRICT_ANSI__.

--- a/gcc/11/patches/0033-gcc10-Fix-libstdc-v3-paths.patch
+++ b/gcc/11/patches/0033-gcc10-Fix-libstdc-v3-paths.patch
@@ -1,4 +1,4 @@
-From c3443778d66979c2734bb02baf24c14b979e7326 Mon Sep 17 00:00:00 2001
+From dc085b1d8e89fed9d12c42caccb50b16a38ab57c Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Mon, 15 Mar 2021 15:55:11 +0100
 Subject: [PATCH 33/39] gcc10: Fix libstdc++v3 paths.

--- a/gcc/11/patches/0034-gcc11-Include-stdint.h-when-sys-mman.h-is-missing.patch
+++ b/gcc/11/patches/0034-gcc11-Include-stdint.h-when-sys-mman.h-is-missing.patch
@@ -1,4 +1,4 @@
-From 0b5fd31f94a96acd4b83b34be52e2915982494fc Mon Sep 17 00:00:00 2001
+From 3e7085275bb907567f3882ae8c7165cdbc8899a9 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 28 May 2021 16:21:55 +0200
 Subject: [PATCH 34/39] gcc11: Include stdint.h when sys/mman.h is missing.

--- a/gcc/11/patches/0035-gcc11-Use-include_next-to-circumvent-fenv.h-include-.patch
+++ b/gcc/11/patches/0035-gcc11-Use-include_next-to-circumvent-fenv.h-include-.patch
@@ -1,4 +1,4 @@
-From 57cdd99bfe45740a2021212005227a089eb5921c Mon Sep 17 00:00:00 2001
+From f181e7aa913f016a77d8732f706e591e92e08d52 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 28 May 2021 16:27:59 +0200
 Subject: [PATCH 35/39] gcc11: Use include_next to circumvent fenv.h include

--- a/gcc/11/patches/0036-gcc11-Fix-to-exception-raised-by-Callable-in-call_on.patch
+++ b/gcc/11/patches/0036-gcc11-Fix-to-exception-raised-by-Callable-in-call_on.patch
@@ -1,4 +1,4 @@
-From c99b141102f736198f6c013f5e58946ccc6d3b95 Mon Sep 17 00:00:00 2001
+From b7f14c053cde9c0be4132895729e12535e22a995 Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Wed, 5 Oct 2022 11:36:32 +0100
 Subject: [PATCH 36/39] gcc11: Fix to exception raised by Callable in call_once

--- a/gcc/11/patches/0037-gcc11-Add-builtin-_AMIGA-define.patch
+++ b/gcc/11/patches/0037-gcc11-Add-builtin-_AMIGA-define.patch
@@ -1,4 +1,4 @@
-From 80cd06ee17ebac85775c82d8b884de7ead35f169 Mon Sep 17 00:00:00 2001
+From 9959aff1f49d727ca28a4b50c4a4ca0c6a183868 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ola=20S=C3=B6der?= <rolfkopman@gmail.com>
 Date: Sun, 9 Apr 2023 22:34:16 +0200
 Subject: [PATCH 37/39] gcc11: Add builtin _AMIGA define.

--- a/gcc/11/patches/0038-gcc11-Changes-to-target-spec-to-allow-an-additional-.patch
+++ b/gcc/11/patches/0038-gcc11-Changes-to-target-spec-to-allow-an-additional-.patch
@@ -1,4 +1,4 @@
-From 89c0d9f8938e548f0ab8e9fdc90626b674756e4a Mon Sep 17 00:00:00 2001
+From 5066ab329ce45ed7e38737ddc2c449e1820edeb9 Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Sun, 17 Sep 2023 12:33:45 +0100
 Subject: [PATCH 38/39] gcc11: Changes to target spec to allow an additional

--- a/gcc/11/patches/0039-gcc11-Fix-math-method-duplication-for-clib4.patch
+++ b/gcc/11/patches/0039-gcc11-Fix-math-method-duplication-for-clib4.patch
@@ -1,0 +1,140 @@
+From ed6d36ab5274fd82afa530bfef8ace926e722af3 Mon Sep 17 00:00:00 2001
+From: Georgios Sokianos <walkero@gmail.com>
+Date: Tue, 3 Oct 2023 17:47:08 +0000
+Subject: [PATCH 39/39] gcc11: Fix math method duplication for clib4
+
+---
+ libstdc++-v3/configure | 111 +++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 111 insertions(+)
+
+diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
+index 6f771d0b1bc3a62bb68bd0657bb295b11c005ba6..4d59406cae075906ba8448e0b68e7a97a68bb583 100755
+--- a/libstdc++-v3/configure
++++ b/libstdc++-v3/configure
+@@ -29321,12 +29321,123 @@ else
+ # Base decisions on target environment.
+ case "${host}" in
+   arm*-*-symbianelf*)
+     # This is a freestanding configuration; there is nothing to do here.
+     ;;
+ 
++  *amigaos*)
++      # RJD:
++      #
++      # When we build the cross compiler we define variables such as
++      # MULTILIB_OPTIONS (see 0001-Changes-for-AmigaOS-version-of-gcc.patch)
++      # which instructs the build to build for both NEWLIB and CLIB4. In the
++      # case that we are building experimental clib4 (AFXGROUP) we want to force
++      # the libstdc++ library to NOT define the following math functions since
++      # they are already in the C-library.
++      #
++      # To do this, we check that the EXP_CLIB4 option is set and that PWD
++      # contains "clib4". That way, we do not change anything for NEWLIB or
++      # "classic" CLIB4.
++      #
++      # TODO: Is there a better way to check this?
++      # if [[ "${EXP_CLIB4}" == "1" && "${PWD}" =~ /clib4/ ]]
++      # then
++	  $as_echo "#define HAVE_ACOSF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_ASINF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_ATAN2F 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_ATANF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_CEILF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_COSF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_COSHF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_EXPF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_FABSF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_FLOORF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_FMODF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_FREXPF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_SQRTF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_HYPOTF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_LDEXPF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_LOG10F 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_LOGF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_MODFF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_POWF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_SINF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_SINHF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_TANF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_TANHF 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_FABSL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_ACOSL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_ASINL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_ATANL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_ATAN2L 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_CEILL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_COSL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_COSHL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_EXPL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_FLOORL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_FMODL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_FREXPL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_SQRTL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_HYPOTL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_LDEXPL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_LOGL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_LOG10L 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_MODFL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_POWL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_SINL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_SINHL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_TANL 1" >>confdefs.h
++
++	  $as_echo "#define HAVE_TANHL 1" >>confdefs.h
++      # fi
++    ;;
++
+   avr*-*-*)
+     $as_echo "#define HAVE_ACOSF 1" >>confdefs.h
+ 
+     $as_echo "#define HAVE_ASINF 1" >>confdefs.h
+ 
+     $as_echo "#define HAVE_ATAN2F 1" >>confdefs.h
+-- 
+2.34.1
+


### PR DESCRIPTION
Added the code we had, that prevents the duplicated error in maths methods